### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ extensions:
 
 use Nette\Application\UI\Form;
 
-class Wizard extends Contribute\FormWizard\Wizard {
+class Wizard extends Contributte\FormWizard\Wizard {
 
     protected function finish(): void 
     {


### PR DESCRIPTION
Fix typo in readme example: Contribute -> Contributte